### PR TITLE
Fix for #5

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,6 +24,9 @@ if (sizeof($argument) === 2) {
 
     $row = $req->fetch();
     if (isset($row['original'])) {
+        if (is_curl()) {
+            die($row['original']);
+        }
         header("Status: 301 Moved Permanently", true, 301);
         header("Location: ".$row['original']);
         add_header();


### PR DESCRIPTION
Si la requête vient de curl (api), on coupe avec le lien original en gardant le 200 OK par défaut (sinon le client d'api retourne la page en suivant le lien original à cause du 301 en dessous)

Fix #5 